### PR TITLE
Pixi-Particles - Version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cookies-js": "^1.2.2",
     "express": "^4.13.4",
     "nunjucks": "^3.0.0",
-    "pixi-particles": "^2.0.0",
+    "pixi-particles": "2.0.0",
     "pixi.js": "^4.0.1",
     "splasher.js": "^0.5.0"
   }


### PR DESCRIPTION
Set pixi-particles to static version 2.0.0 because changes in pixi-particles 2.1.0 breaks code!